### PR TITLE
[fix] add the missing comma in pyproject.toml to enable correct pip i…

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
     "torch==2.1.2", "ipdb",
     "transformers==4.36.2", 
     "toml", "attributedict",
-    "accelerate==0.25.0"
+    "accelerate==0.25.0",
     "protobuf",
 ]
 


### PR DESCRIPTION
I encountered the following error when trying to install the dependencies of KIVI: `pip._vendor.tomli.TOMLDecodeError: Unclosed array (at line 21, column 5)`, and I noticed that a missing comma in pyproject.toml incurs this error.