### PR TITLE
[FIX] use flash attention in example.py

### DIFF
--- a/example.py
+++ b/example.py
@@ -17,6 +17,7 @@ config.k_bits = 2 # KiVi currently support 2/4 K/V bits
 config.v_bits = 2
 config.group_size = 32 
 config.residual_length = 32 # corresponding to the number of recent fp16 tokens
+config.use_flash = True
 CACHE_DIR = "./"
 
 model = LlamaForCausalLM_KIVI.from_pretrained(


### PR DESCRIPTION
example.py was using config that didn't specify `use_flash`. But vanilla attention is not supported yet. So we specify use_flash in example.py's config file.